### PR TITLE
Overload readFloat64 to work around a perceived bug

### DIFF
--- a/CounterPortDriverApp/Db/counter.db
+++ b/CounterPortDriverApp/Db/counter.db
@@ -3,14 +3,14 @@
 record(ai, "$(USER):get:set:one")
 {
     field(DTYP, "asynFloat64")
-    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCOPE_COUNTER")
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))COUNTER")
     field(SCAN, "I/O Intr")
   }
 
 record(ai, "$(USER):get:set:two")
 {
     field(DTYP, "asynFloat64")
-    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCOPE_COUNTER_2")
+    field(INP, "@asyn($(PORT),$(ADDR),$(TIMEOUT))SCALAR")
     field(SCAN, "I/O Intr")
   }
 

--- a/CounterPortDriverApp/src/counter.cpp
+++ b/CounterPortDriverApp/src/counter.cpp
@@ -6,16 +6,18 @@ void counterTask(void *driverPointer);
 CounterDriver::CounterDriver(const char *portName) : asynPortDriver(
     portName,
     1,
+    asynFloat64Mask | asynDrvUserMask,
     asynFloat64Mask,
-    asynFloat64Mask,
-    0,
+    ASYN_MULTIDEVICE,
     1,
     0,
     0
     )
 {
-  createParam(P_CounterString, asynParamFloat64, &P_Count);
-  createParam(P_CounterString2, asynParamFloat64, &P_Count2);
+  counter = 0.;
+  scalar = 0.;
+  createParam(COUNTER_STRING, asynParamFloat64, &_counter);
+  createParam(SCALAR_STRING, asynParamFloat64, &_scalar);
   asynStatus status;
   status = (asynStatus)(epicsThreadCreate("LujkoCounterTask", epicsThreadPriorityMedium, epicsThreadGetStackSize(epicsThreadStackMedium), (EPICSTHREADFUNC)::counterTask, this) == NULL);
   if (status)
@@ -38,16 +40,43 @@ void CounterDriver::counterTask(void)
   for(int x = 0; x <=100; x++)
   {
     sleep(4);
-    setDoubleParam(P_Count, x);
-    getDoubleParam(P_Count, &twice);
-    callParamCallbacks();
-    //printf("it grabbed this: %f\n", twice);
-    setDoubleParam(P_Count2, 33);
-    getDoubleParam(P_Count2, &thrice);
-    printf("Retrieved vals: %f, %f", twice, thrice);
+    counter = x * 1.0;
+    scalar = 33.;
+    setDoubleParam(_counter,counter);
+    setDoubleParam(_scalar,scalar);
     callParamCallbacks();
   }
 }
+
+asynStatus CounterDriver::readFloat64(asynUser *pasynUser, epicsFloat64 *value) {
+  static const char *functionName = "readFloat64Overload";
+  const char * paramName;
+  asynStatus status = asynSuccess;
+  int addr;
+  int function = pasynUser->reason;
+  status = getParamName(function, &paramName);
+  getAddress(pasynUser, &addr);
+  epicsTimeStamp timeStamp; getTimeStamp(&timeStamp);
+  status = (asynStatus) getDoubleParam(addr,function,value);
+  pasynUser->timestamp = timeStamp;
+  getParamAlarmStatus(addr, function, &pasynUser->alarmStatus);
+  getParamAlarmSeverity(addr, function, &pasynUser->alarmSeverity);
+  if (status == asynParamUndefined) 
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+                  "%s:%s: status=%d, function=%d, name=%s, value is undefined", 
+                  driverName, functionName, status, function, paramName );
+  else if (status) 
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+                  "%s:%s: status=%d, function=%d, name=%s, value=%f", 
+                  driverName, functionName, status, function, paramName, *value);
+  else        
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
+              "%s:%s: function=%d, name=%s, value=%f\n", 
+              driverName, functionName, function, paramName, *value);
+  return status;
+}
+
+
 
 extern "C" {
   int CounterDriverConfigure(const char* portName) {

--- a/CounterPortDriverApp/src/counter.h
+++ b/CounterPortDriverApp/src/counter.h
@@ -1,40 +1,27 @@
 //Counter.h 
-
-#include <iostream>
-#include <cstdint>
-#include <memory>
-#include <functional>
-#include <map>
-
+#include <epicsString.h>
 #include <iocsh.h>
+#include <iostream>
 #include <epicsExport.h>
 #include <epicsThread.h>
-#include <epicsEvent.h>
-#include <epicsTimer.h>
 #include <epicsTypes.h>
 #include <asynPortDriver.h>
 
-using namespace std;
+#define COUNTER_STRING "COUNTER"
+#define SCALAR_STRING "SCALAR"
 
-#define P_CounterString "SCOPE_COUNTER"
-#define P_CounterString2 "SCOPE_COUNTER_2"
+static const char *driverName = "Counter";
 
 class CounterDriver : public asynPortDriver {
   public:
     CounterDriver(const char *portName);
     void counterTask(void);
-  protected:
-    int P_Count;
-    int P_Count2;
+    virtual asynStatus readFloat64(asynUser *pasynUser, epicsFloat64 *value);
+
+  private:
+    int _counter;
+    int _scalar;
+    double counter;
+    double scalar;
 };
 
-//New Stuff, should be able to comment out and reset?
-/**
-class GetterDriver : public asynPortDriver {
-  public:
-    GetterDriver(const char *portName);
-    void getterTask(void);
-  protected:
-    int P_Getter;
-};
-**/

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,43 +1,32 @@
-# RELEASE - Location of external support modules
+# RELEASE.local
 #
-# IF YOU CHANGE ANY PATHS in this file or make API changes to
-# any modules it refers to, you should do a "make rebuild" in
-# this application's top level directory.
-#
-# The EPICS build process does not check dependencies against
-# any files from outside the application, so it is safest to
-# rebuild it completely if any modules it depends on change.
-#
-# Host- or target-specific settings can be given in files named
-#  RELEASE.$(EPICS_HOST_ARCH).Common
-#  RELEASE.Common.$(T_A)
-#  RELEASE.$(EPICS_HOST_ARCH).$(T_A)
-#
-# This file is parsed by both GNUmake and an EPICS Perl script,
-# so it may ONLY contain definititions of paths to other support
-# modules, variable definitions that are used in module paths,
-# and include statements that pull in other RELEASE files.
-# Variables may be used before their values have been set.
-# Build variables that are NOT used in paths should be set in
-# the CONFIG_SITE file.
+# Read definitions of:
+#       EPICS_SITE_TOP
+#       BASE_MODULE_VERSION
+#       EPICS_MODULES
+# from one of the following options
+-include $(TOP)/RELEASE_SITE
 
-# Variables and paths to dependent modules:
-#MODULES = /path/to/modules
-#MYMODULE = $(MODULES)/my-module
+# ==========================================================
+# Define the version strings for all needed modules
+# Use naming pattern:
+#   FOO_MODULE_VERSION = R1.2
+# so scripts can extract version strings
+# Don't set your version to anything such as "test" that
+# could match a directory name.
+# ==========================================================
+ASYN_MODULE_VERSION             = R4.39-1.0.1
 
-# If using the sequencer, point SNCSEQ at its top directory:
-#SNCSEQ = $(MODULES)/seq-ver
-ASYN_MODULE_VERSION=R4.39-1.0.1
-ASYN = $(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
-# EPICS_BASE should appear last so earlier modules can override stuff:
-EPICS_BASE = /afs/slac/g/lcls/epics/base/R7.0.3.1-1.0
 
-# Set RULES here if you want to use build rules from somewhere
-# other than EPICS_BASE:
-#RULES = $(MODULES)/build-rules
+# ==========================================================
+# Define module paths using pattern
+# FOO = $(EPICS_MODULES)/foo/$(FOO_MODULE_VERSION)
+#  or
+# FOO = /Full/Path/To/Development/Version
+# ==========================================================
+ASYN             = $(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
 
-# These lines allow developers to override these RELEASE settings
-# without having to modify this file directly.
--include $(TOP)/../RELEASE.local
--include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
--include $(TOP)/configure/RELEASE.local
+# =====================================================================
+# Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths
+# ====================================================================
+EPICS_BASE=$(BASE_SITE_TOP)/$(BASE_MODULE_VERSION)

--- a/iocBoot/iocJeremyPortTest/Makefile
+++ b/iocBoot/iocJeremyPortTest/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/iocBoot/iocJeremyPortTest/st.cmd
+++ b/iocBoot/iocJeremyPortTest/st.cmd
@@ -1,0 +1,25 @@
+#!../../bin/rhel7-x86_64/CounterPortDriver
+
+#- You may have to change CounterPortDriver to something else
+#- everywhere it appears in this file
+
+< envPaths
+
+cd "${TOP}"
+
+## Register all support components
+dbLoadDatabase "dbd/CounterPortDriver.dbd"
+CounterPortDriver_registerRecordDeviceDriver pdbbase
+
+##Driver Launches
+CounterDriverConfigure("jeremy")
+##GetterDriverConfigure("lujko1")
+##WaterDriverConfigure("lujko2")
+
+## Load record instances
+dbLoadRecords("db/counter.db", "USER=jeremy,PORT=jeremy,ADDR=0,TIMEOUT=1")
+cd "${TOP}/iocBoot/${IOC}"
+iocInit()
+
+## Start any sequence programs
+#seq sncxxx,"user=lujko"


### PR DESCRIPTION
* Add overloaded readFloat64 to counter.cpp --> *very* similar to asyn base version.  Suspect problem in asyn base version _might_ be in asynPortDriver::parseAsynUser ([link](https://github.com/epics-modules/asyn/blob/master/asyn/asynPortDriver/asynPortDriver.cpp#L1924-L1934))
* Restructure configure/RELEASE